### PR TITLE
fix: loosen pins on libraries to fix conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ packages = [
     { include = "sensirion_ble", from = "src" },
 ]
 dependencies = [
-    "bluetooth-data-tools~=0.1",
-    "bluetooth-sensor-state-data~=1.6",
-    "home-assistant-bluetooth~=1.6",
-    "sensor-state-data~=2.9",
+    "bluetooth-data-tools>=0.1",
+    "bluetooth-sensor-state-data>=1.6",
+    "home-assistant-bluetooth>=1.6",
+    "sensor-state-data>=2.9",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
The version pins were blocking https://github.com/home-assistant/core/pull/94145