### PR TITLE
feat(parser): add support for CO2 Gadget devices

### DIFF
--- a/src/sensirion_ble/converters.py
+++ b/src/sensirion_ble/converters.py
@@ -60,9 +60,35 @@ def _convert_type_8(raw_data: bytes) -> ConversionResult:
     }
     return ConversionResult(raw_data[2:4].hex().upper(), data)
 
+# Add parcer for Advanced CO2 Gadget
+def _convert_type_a(raw_data: bytes) -> ConversionResult:
+    # Check for CO2 Gadget pattern: 00 0A 00 51
+    if len(raw_data) < 10 or raw_data[0:4] != b'\x00\x0a\x00\x51':
+        return None  # Not our format
+        
+    # Parse all values (little-endian)
+    temp_raw = int.from_bytes(raw_data[4:6], 'little')
+    hum_raw = int.from_bytes(raw_data[6:8], 'little')
+    co2_raw = int.from_bytes(raw_data[8:10], 'little')
+    
+    # Convert to physical values
+    temperature = round((temp_raw * 175.0 / 65535) - 45.0, 1)
+    humidity = round(hum_raw * 100.0 / 65535)
+    co2 = co2_raw
+    
+    data = {
+        # The datasheet for the SCD4x sensor states that the accuracy
+        # of the temperature sensor is ±0.8°C, so one digit after the
+        # decimal point should be enough.
+        TEMP_CELSIUS: temperature,
+        RH_PERCENTAGE: humidity,
+        CO2_PPM: co2,
+    }
+    return ConversionResult(raw_data[2:4].hex().upper(), data)
 
 CONVERTERS = {
     b"\x00\x04": _convert_type_4,
     b"\x00\x06": _convert_type_6,
     b"\x00\x08": _convert_type_8,
+    b"\x00\x0a": _convert_type_a,
 }


### PR DESCRIPTION
feat(parser): add support for CO2 Gadget devices

Add new parser `_convert_type_a` to handle data format from: https://github.com/melkati/CO2-Gadget

Key changes:
- New converter for data pattern: `00 0A 00 51 [TEMP] [HUM] [CO2]...`
- Properly decodes:
  - Temperature (28.1°C from sample: 00 0A 00 51 EB 6A AE 74 2C 02)
  - Humidity (45% from sample: 00 0A 00 51 29 6B 18 75 22 02)
  - CO2 concentration (547ppm from same sample)
- Added to CONVERTERS dictionary under key b"\x00\x0a"

Tested with real-world samples matching:
1. 000A0051EB6AAE742C02000000000000 → 28.1°C, ?, 547ppm
2. 000A0051296B18752202000000000000 → 28.3°C, 45%, 546ppm

Maintains full backward compatibility with existing parsers.