### PR TITLE
Added support for the SGP based "Air Quality Minion"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Parser for Sensirion BLE devices.
 
 * [MyCO2 (aka SCD4x CO2 Gadget)](https://sensirion.com/products/catalog/SCD4x-CO2-Gadget/)
 * [SHT43 DemoBoard](https://sensirion.com/products/catalog/SHT43-DemoBoard)
+* Air Quality Minion
 
 ## Untested devices
 

--- a/src/sensirion_ble/converters.py
+++ b/src/sensirion_ble/converters.py
@@ -9,6 +9,26 @@ from sensirion_ble.types import ConversionResult
 CO2_PPM = (SensorDeviceClass.CO2, Units.CONCENTRATION_PARTS_PER_MILLION)
 RH_PERCENTAGE = (SensorDeviceClass.HUMIDITY, Units.PERCENTAGE)
 TEMP_CELSIUS = (SensorDeviceClass.TEMPERATURE, Units.TEMP_CELSIUS)
+TVOC_RAW = (SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS, Units.CONCENTRATION_PARTS_PER_BILLION)
+AQI = (SensorDeviceClass.AQI, None)
+
+def _convert_type_3(raw_data: bytes) -> ConversionResult:
+    # AQ Minion
+    temp_ticks, humidity_ticks, aqi, tvoc_raw, = struct.unpack("<HHHH", raw_data[4:12])
+    # Conversion:
+    # T = -45 + ((175.0 * ticks) / (2^16 - 1))
+    # RH = (100.0 * ticks) / (2^16 - 1)
+    # AQI = transmitted value (Air Quality Index)
+    # VOC = transmitted value
+    temp = -45 + ((175.0 * temp_ticks) / (2**16 - 1))
+    humidity = (100.0 * humidity_ticks) / (2**16 - 1)
+    data = {
+        TEMP_CELSIUS: round(temp, 1),
+        RH_PERCENTAGE: round(humidity, 1),
+        AQI: aqi,
+        TVOC_RAW: tvoc_raw,
+    }
+    return ConversionResult(raw_data[2:4].hex().upper(), data)
 
 
 def _convert_type_4(raw_data: bytes) -> ConversionResult:
@@ -62,6 +82,7 @@ def _convert_type_8(raw_data: bytes) -> ConversionResult:
 
 
 CONVERTERS = {
+    b"\x00\x03": _convert_type_3,
     b"\x00\x04": _convert_type_4,
     b"\x00\x06": _convert_type_6,
     b"\x00\x08": _convert_type_8,


### PR DESCRIPTION
I still have two of those Air Quality Minions lying around and I'd love to use them with home assistant so I added support for it.
This SGP based BLE sensor measures TVOC in addition to temperature and relative humidity.
The byte values are nearly the same as for the My CO2 sensor, as seen in [the pdf](https://github.com/akx/sensirion-ble/blob/main/reference/Sensirion_BLE_communication_protocol.pdf) and here:
https://sensirion.github.io/ble-services/#/live-data

Some live data:

```
00 03 f2 d1 6c 65 04 5b ff ff ff ff              ....le.[....
00 03 f2 d1 9d 65 24 59 00 00 69 49              .....e$Y..iI
00 03 f2 d1 d9 65 9c 58 00 00 c6 47              .....e.X...G
00 03 f2 d1 f4 65 f8 57 00 00 30 47              .....e.W..0G
```

Each byte from left to right: Ad type, Sample type, Device id, Device id, Temperature-LSB, Temperature-MSB, Humidity-LSB, Humidity-MSB, VOC-LSB, VOC-MSB, reserved-LSB, reserved-MSB

And the pdf above lets us know that the reserved bytes are for TVOC_RAW, which is not used in the MyAmbiance app.

And I'll also just drop this data sheet here: https://sensirion.com/media/documents/0E2E7340/617BDB64/Sensirion_Gas_Sensors_Datasheet_SGPC3.pdf


I tested the converter with this script:

```
import asyncio
from bleak import BleakScanner
from sensirion_ble.converters import CONVERTERS

SENSIRION_COMPANY_ID = 0x06D5

async def main():
    devices = await BleakScanner.discover(return_adv=True, timeout=10.0)
    for d, adv in devices.values():
        if SENSIRION_COMPANY_ID in adv.manufacturer_data:
            raw = adv.manufacturer_data[SENSIRION_COMPANY_ID]
            print(f"Name:    {d.name}")
            print(f"Address: {d.address}")
            print(f"Raw hex: {raw.hex()}")
            print(f"Type bytes: {raw[:2].hex()}")

            converter = CONVERTERS.get(raw[:2])
            if converter:
                result = converter(raw)
                print(f"Device ID: {result.identifier}")
                for (device_class, unit), value in result.data.items():
                    print(f"  {device_class}: {value} {unit}")
            else:
                print(f"  (no converter for type bytes {raw[:2].hex()})")
            print()

asyncio.run(main())
```

And it correctly showed the values, which were the same as in the MyAmbiance app:

```
Name:    AQ Minion
Address: <redacted>
Raw hex: <redacted>
Type bytes: 0003
Device ID: <redacted>
  temperature: 27.3 °C
  humidity: 29.1 %
  aqi: 86 None
  volatile_organic_compounds: 18150 ppb
```